### PR TITLE
fix: more accurate timing

### DIFF
--- a/referee/Board.py
+++ b/referee/Board.py
@@ -1,5 +1,17 @@
 import time
 
+from threading import Lock
+
+# Why we need this? Please see the comments
+# in the calculate_time_for_team() function
+# in app.py.
+if time.get_clock_info('perf_counter').monotonic:
+    _realtime_func = time.perf_counter
+else:
+    _realtime_func = time.monotonic # less precise than time.perf_counter
+
+def realtime() -> float:
+    return _realtime_func()
 
 class BoardGame:
     def __init__(self, size, board, room_id, match_id, team1_id="xx1+x", team2_id="xx2+o"):
@@ -24,7 +36,10 @@ class BoardGame:
             "score1": self.score1,
             "score2": self.score2
         }
-        self.timestamps = [time.time()] * 2
+        self.timestamps = [realtime()] * 2
+        self.lastFetchTime: list[float] = [-1.0, -1.0]
+        self.lastBoardUpdateTime = realtime()
+        self.timeUpdateLock = Lock()
         self.start_game = False
 
     def init_board(self):


### PR DESCRIPTION
## Pull request này giải quyết vấn đề gì?

Em thưa thầy, trước PR này, khi team1 tạo phòng thì referee sẽ bắt đầu tính giờ cho team2 luôn, chứ không đợi team2 request tới `/init` mới bắt đầu tính giờ. Như vậy sẽ không công bằng cho team2, vì team2 luôn phải vào sau team1 ạ. Hôm trước có bạn ý kiến cái này rồi ạ.

## Pull request này giải quyết vấn đề như thế nào?

Em sử dụng hai biện pháp sau:

1. **Chỉ tính giờ cho mỗi team khi team đó đã fetch game info mới nhất** (fetch game info chính là truy cập vào route `/`). Lý do: mỗi khi board có update - chẳng hạn, khi vừa mới tạo game (initialize) hay khi đối thủ vừa đi một nước cờ mới - thì team mình chưa nhìn thấy board, chưa biết nội dung mới nhất của board (và trong trường hợp initialize thì thậm chí còn chưa biết board có size bao nhiêu), như vậy chẳng nên tính giờ cho một team khi team đó còn chưa nhìn thấy *last board update*.
2. **Nếu một team không fetch game info mới nhất trong khoảng thời gian quá lâu, thì sẽ bắt đầu tính giờ cho team đó.** Lý do: rất có thể team đó đã bị crash hoặc trong quá trình "tranh thủ" thời gian team khác move để tính toán các nước đi về sau, đã "quá đà" và dẫn đến mất nhiều thời gian hơn dự kiến - số thời gian trống này cần được tính vào thời gian chơi game của team đó !

## Trường hợp đặc biệt

Trong trường hợp cả 2 team đều không fetch game info mới nhất và cũng không đi nước cờ mới trong khoảng thời gian quá lâu, thì referee sẽ tính giờ cho *team đối thủ của team đi nước cờ cuối cùng*. Điều này hoàn toàn phù hợp với hai biện pháp em đã nêu ở trên, và phù hợp với thực tế rằng đây là một turn-based game.

## Thuật toán

Để thực hiện hai biện pháp trên, code referee mà em viết trong PR này sử dụng các biến mới sau:

- `lastBoardUpdate` của mỗi room/board game
- `lastFetchTime` của mỗi team trong mỗi room, sẽ được cập nhật trong route `/`.

Ngoài ra sử dụng các biến đã có từ trước:

- `timestamp` của mỗi team trong mỗi room
- `usedTime` là thời gian mỗi team đã sử dụng (chính là `game_info["time1"]` hoặc `game_info["time2"]`
- `now = realtime()` (đây là hàm em mới code thêm, có độ chính xác cao hơn `time.time()`).

Mỗi lần cần cập nhật thời gian cho một team, hệ thống sẽ gọi hàm `calculate_time_for_team()` trong `app.py`. Hàm này xét các trường hợp như sau:

1. TH1: `lastFetchTime >= lastBoardUpdateTime`: Chứng tỏ team này đã nhìn thấy board state mới nhất, tính giờ cho team như sau: `usedTime += now - max(timestamp, lastFetchTime)`
2. TH2: `lastFetchTime < lastBoardUpdateTime`: Chứng tỏ team này chưa nhìn thấy last board update, chờ khoảng 5s cho team đó fetch game info ; nếu quá 5s chưa fetch game info thì mới bắt đầu tính giờ cho team đó. Tại sao lại là 5 giây? Bởi vì code backend hiện tại để chu kỳ fetch game info là 3s (`time.sleep(3)`).

TH2 được minh họa cụ thể như hình dưới:

![demonstration](https://github.com/nnphuc/UET_AICaroGame/assets/79616907/5e0847bc-54f0-4ecb-a312-274223a8d192)

Sau mỗi lần gọi `calculate_time_for_team()` thì `timestamp` sẽ được gán bằng `now`, như vậy các trường hợp nói trên là phân tách hoàn toàn với nhau. Chẳng hạn ở trường hợp 2, có 3 trường hợp con ứng với 3 sơ đồ như hình vẽ : nếu trường hợp con 1 xảy ra thì trường hợp con xảy ra tiếp theo chắc chắn phải là trường hợp con 2 hoặc 3, do sự phân tách hoàn toàn đã nói trên. Do đó, em thấy rằng sẽ không xảy ra chuyện một khoảng thời gian nào đó bị cộng dồn nhiều lần thay vì một lần, dẫn đến thời gian của một team bị tính nhiều hơn so với thực tế (chẳng hạn ở TH2, nếu trường hợp con 3 xảy ra 2 lần thì khoảng thời gian Y bị cộng những 2 lần, dẫn đến thời gian của team dài hơn so với thực tế một khoảng là `2Y - Y = Y`). Như vậy có thể coi là thuật toán này đã đảm bảo công bằng cho cả 2 team.

Do có hàm `update_time()` chạy trong một thread khác cũng sử dụng hàm `calculate_time_for_team`, nên em có dùng thêm một `timeUpdateLock` cho mỗi board game để đảm bảo việc tính toán thời gian phân tách hoàn toàn trong môi trường multithread.

## Demo

Em đã quay lại hoạt động của hệ thống trong 3 trường hợp:

1. BEFORE FIX: Trước khi em viết code sửa lỗi này.
2. AFTER FIX, 2 team join vào cùng một lúc (team2 vào ngay sau team1)
3. AFTER FIX, team2 vào sau team1 một khoảng thời gian khá dài (15 giây).

Hai team đều sử dụng một agent (random move), như vậy thời gian fetch game info và make moves của hai team là bằng nhau.

Video em quay ở [đây](https://youtu.be/WCkvSo8GYic), tuy nhiên em sẽ tóm tắt diễn biến của video như sau:

1. Với trường hợp 1, mặc dù team2 đi sau và chịu thiệt thời gian hơn 15s khi chưa kịp kết nối đến referee, nhưng đến cuối trận thời gian của team1 lại nhiều hơn team2 những 30s.
2. Với trường hợp 2, có thể thấy thời gian của 2 team là rất sát nhau và tăng đều 3 - 5ms mỗi nước đi, phản ánh thực tế rằng 2 team có thực lực ngang nhau. Cuối trận, 2 team chỉ lệch nhau 1ms (0.001s).
3. Với trường hợp 3, team2 cũng vào muộn 15s. Trong 5s đầu kể từ khi bắt đầu trận đấu và team1 đã đi nước đầu tiên, đồng hồ cho team2 vẫn chỉ số 0. Đây là thời gian chờ team2 fetch game info. Tuy nhiên, do quá 5s mà team2 vẫn chưa vào, đồng hồ bắt đầu nảy số, và đến khi team2 kết nối và đi nước cờ của mình, đồng hồ của team2 chỉ 10s, phù hợp với dự đoán 15s - 5s.

## Phần backend và frontend có thay đổi gì không?

PR này hoàn toàn không thay đổi code ở backend và frontend ; các nhóm có thể yên tâm sử dụng code cũ, song nên cập nhật code referee mới nhất nếu muốn chạy referee ở localhost.
